### PR TITLE
Fix bug in parallel_for

### DIFF
--- a/vmcache.cpp
+++ b/vmcache.cpp
@@ -1696,7 +1696,7 @@ void parallel_for(uint64_t begin, uint64_t end, uint64_t nthreads, Fn fn) {
    for (unsigned i=0; i<nthreads; i++) {
       threads.emplace_back([&,i]() {
          uint64_t b = (perThread*i) + begin;
-         uint64_t e = (i==(nthreads-1)) ? end : ((b+perThread) + begin);
+         uint64_t e = (i==(nthreads-1)) ? end : (b+perThread);
          fn(i, b, e);
       });
    }


### PR DESCRIPTION
parallel_for added the begin of the global range to the end of the thread-local range twice which, depending on the thread count, lead to fully duplicated warehouses in TPC-C. This can be observed when calling countw on the TPC-C tables with the different warehouse ids. Some will have double the elements.

This code currently calculates the per-thread ranges:

uint64_t b = (perThread*i) + begin;
uint64_t e = (i==(nthreads-1)) ? end : ((b+perThread) + begin);

Imagine a scenario where begin=100, end=300 and nthreads=2. In that case:

Thread 0 gets:
b = 100
e = 300 (bc. e = (b + perThread) + begin = (100 + 100) + 100) Thread 1 gets: b = 200
e = 300 (bc. i == nthreads-1)

which means that the range 200-300 is executed twice.